### PR TITLE
FieldDefinition added to convertFieldValueToForm method

### DIFF
--- a/Form/DataMapper/CreateContentMapper.php
+++ b/Form/DataMapper/CreateContentMapper.php
@@ -41,7 +41,8 @@ class CreateContentMapper extends DataMapper
         $handler = $this->fieldTypeHandlerRegistry->get( $fieldTypeIdentifier );
         $form->setData(
             $handler->convertFieldValueToForm(
-                $contentType->getFieldDefinition( $fieldDefinitionIdentifier )->defaultValue
+                $contentType->getFieldDefinition( $fieldDefinitionIdentifier )->defaultValue,
+                $fieldDefinition
             )
         );
     }

--- a/Form/DataMapper/CreateUserMapper.php
+++ b/Form/DataMapper/CreateUserMapper.php
@@ -41,7 +41,8 @@ class CreateUserMapper extends DataMapper
         $handler = $this->fieldTypeHandlerRegistry->get( $fieldTypeIdentifier );
         $form->setData(
             $handler->convertFieldValueToForm(
-                $contentType->getFieldDefinition( $fieldDefinitionIdentifier )->defaultValue
+                $contentType->getFieldDefinition( $fieldDefinitionIdentifier )->defaultValue,
+                $fieldDefinition
             )
         );
     }

--- a/Form/DataMapper/UpdateContentMapper.php
+++ b/Form/DataMapper/UpdateContentMapper.php
@@ -47,7 +47,8 @@ class UpdateContentMapper extends DataMapper
                 $content->getFieldValue(
                     $fieldDefinitionIdentifier,
                     $contentUpdateStruct->initialLanguageCode
-                )
+                ),
+                $fieldDefinition
             )
         );
     }

--- a/Form/DataMapper/UpdateUserMapper.php
+++ b/Form/DataMapper/UpdateUserMapper.php
@@ -59,7 +59,8 @@ class UpdateUserMapper extends DataMapper
                     $user->getFieldValue(
                         $fieldDefinitionIdentifier,
                         $userUpdateStruct->contentUpdateStruct->initialLanguageCode
-                    )
+                    ),
+                    $fieldDefinition
                 )
             );
         }

--- a/Form/FieldTypeHandler.php
+++ b/Form/FieldTypeHandler.php
@@ -26,7 +26,7 @@ abstract class FieldTypeHandler implements FieldTypeHandlerInterface
     /**
      * @inheritdoc
      */
-    abstract public function convertFieldValueToForm( Value $value, FieldDefinition $fieldDefinition );
+    abstract public function convertFieldValueToForm( Value $value, FieldDefinition $fieldDefinition = null );
 
     /**
      * @inheritdoc

--- a/Form/FieldTypeHandler.php
+++ b/Form/FieldTypeHandler.php
@@ -26,7 +26,7 @@ abstract class FieldTypeHandler implements FieldTypeHandlerInterface
     /**
      * @inheritdoc
      */
-    abstract public function convertFieldValueToForm( Value $value );
+    abstract public function convertFieldValueToForm( Value $value, FieldDefinition $fieldDefinition );
 
     /**
      * @inheritdoc

--- a/Form/FieldTypeHandler/BinaryFile.php
+++ b/Form/FieldTypeHandler/BinaryFile.php
@@ -22,7 +22,7 @@ class BinaryFile extends FieldTypeHandler
      *
      * @param \eZ\Publish\Core\FieldType\Image\Value $value
      */
-    public function convertFieldValueToForm( Value $value )
+    public function convertFieldValueToForm( Value $value, FieldDefinition $fieldDefinition = null )
     {
         return null;
     }

--- a/Form/FieldTypeHandler/Checkbox.php
+++ b/Form/FieldTypeHandler/Checkbox.php
@@ -32,7 +32,7 @@ class Checkbox extends FieldTypeHandler
      *
      * @return boolean
      */
-    public function convertFieldValueToForm( Value $value )
+    public function convertFieldValueToForm( Value $value, FieldDefinition $fieldDefinition )
     {
         return $value->bool;
     }

--- a/Form/FieldTypeHandler/Checkbox.php
+++ b/Form/FieldTypeHandler/Checkbox.php
@@ -32,7 +32,7 @@ class Checkbox extends FieldTypeHandler
      *
      * @return boolean
      */
-    public function convertFieldValueToForm( Value $value, FieldDefinition $fieldDefinition )
+    public function convertFieldValueToForm( Value $value, FieldDefinition $fieldDefinition = null )
     {
         return $value->bool;
     }

--- a/Form/FieldTypeHandler/Country.php
+++ b/Form/FieldTypeHandler/Country.php
@@ -71,7 +71,7 @@ class Country extends FieldTypeHandler
      *
      * @return array
      */
-    public function convertFieldValueToForm( Value $value, FieldDefinition $fieldDefinition )
+    public function convertFieldValueToForm( Value $value, FieldDefinition $fieldDefinition = null )
     {
         return $value->countries;
     }

--- a/Form/FieldTypeHandler/Country.php
+++ b/Form/FieldTypeHandler/Country.php
@@ -71,7 +71,7 @@ class Country extends FieldTypeHandler
      *
      * @return array
      */
-    public function convertFieldValueToForm( Value $value )
+    public function convertFieldValueToForm( Value $value, FieldDefinition $fieldDefinition )
     {
         return $value->countries;
     }

--- a/Form/FieldTypeHandler/Date.php
+++ b/Form/FieldTypeHandler/Date.php
@@ -38,7 +38,7 @@ class Date extends FieldTypeHandler
      *
      * @return DateTime
      */
-    public function convertFieldValueToForm( Value $value )
+    public function convertFieldValueToForm( Value $value, FieldDefinition $fieldDefinition )
     {
         return $value->date;
     }

--- a/Form/FieldTypeHandler/Date.php
+++ b/Form/FieldTypeHandler/Date.php
@@ -38,7 +38,7 @@ class Date extends FieldTypeHandler
      *
      * @return DateTime
      */
-    public function convertFieldValueToForm( Value $value, FieldDefinition $fieldDefinition )
+    public function convertFieldValueToForm( Value $value, FieldDefinition $fieldDefinition = null )
     {
         return $value->date;
     }

--- a/Form/FieldTypeHandler/DateAndTime.php
+++ b/Form/FieldTypeHandler/DateAndTime.php
@@ -41,7 +41,7 @@ class DateAndTime extends FieldTypeHandler
      *
      * @return DateTime
      */
-    public function convertFieldValueToForm( Value $value, FieldDefinition $fieldDefinition )
+    public function convertFieldValueToForm( Value $value, FieldDefinition $fieldDefinition = null )
     {
         return $value->value;
     }

--- a/Form/FieldTypeHandler/DateAndTime.php
+++ b/Form/FieldTypeHandler/DateAndTime.php
@@ -41,7 +41,7 @@ class DateAndTime extends FieldTypeHandler
      *
      * @return DateTime
      */
-    public function convertFieldValueToForm( Value $value )
+    public function convertFieldValueToForm( Value $value, FieldDefinition $fieldDefinition )
     {
         return $value->value;
     }

--- a/Form/FieldTypeHandler/Email.php
+++ b/Form/FieldTypeHandler/Email.php
@@ -37,7 +37,7 @@ class Email extends FieldTypeHandler
      *
      * @return string
      */
-    public function convertFieldValueToForm( Value $value )
+    public function convertFieldValueToForm( Value $value, FieldDefinition $fieldDefinition )
     {
         return $value->email;
     }

--- a/Form/FieldTypeHandler/Email.php
+++ b/Form/FieldTypeHandler/Email.php
@@ -37,7 +37,7 @@ class Email extends FieldTypeHandler
      *
      * @return string
      */
-    public function convertFieldValueToForm( Value $value, FieldDefinition $fieldDefinition )
+    public function convertFieldValueToForm( Value $value, FieldDefinition $fieldDefinition = null )
     {
         return $value->email;
     }

--- a/Form/FieldTypeHandler/Float.php
+++ b/Form/FieldTypeHandler/Float.php
@@ -60,7 +60,7 @@ class Float extends FieldTypeHandler
      *
      * @return float
      */
-    public function convertFieldValueToForm( Value $value )
+    public function convertFieldValueToForm( Value $value, FieldDefinition $fieldDefinition )
     {
         return $value->value;
     }

--- a/Form/FieldTypeHandler/Float.php
+++ b/Form/FieldTypeHandler/Float.php
@@ -60,7 +60,7 @@ class Float extends FieldTypeHandler
      *
      * @return float
      */
-    public function convertFieldValueToForm( Value $value, FieldDefinition $fieldDefinition )
+    public function convertFieldValueToForm( Value $value, FieldDefinition $fieldDefinition = null )
     {
         return $value->value;
     }

--- a/Form/FieldTypeHandler/Image.php
+++ b/Form/FieldTypeHandler/Image.php
@@ -22,7 +22,7 @@ class Image extends FieldTypeHandler
      *
      * @param \eZ\Publish\Core\FieldType\Image\Value $value
      */
-    public function convertFieldValueToForm( Value $value, FieldDefinition $fieldDefinition )
+    public function convertFieldValueToForm( Value $value, FieldDefinition $fieldDefinition = null )
     {
         return null;
     }

--- a/Form/FieldTypeHandler/Image.php
+++ b/Form/FieldTypeHandler/Image.php
@@ -22,7 +22,7 @@ class Image extends FieldTypeHandler
      *
      * @param \eZ\Publish\Core\FieldType\Image\Value $value
      */
-    public function convertFieldValueToForm( Value $value )
+    public function convertFieldValueToForm( Value $value, FieldDefinition $fieldDefinition )
     {
         return null;
     }

--- a/Form/FieldTypeHandler/Integer.php
+++ b/Form/FieldTypeHandler/Integer.php
@@ -60,7 +60,7 @@ class Integer extends FieldTypeHandler
      *
      * @return int
      */
-    public function convertFieldValueToForm( Value $value, FieldDefinition $fieldDefinition )
+    public function convertFieldValueToForm( Value $value, FieldDefinition $fieldDefinition = null )
     {
         return (int)$value->value;
     }

--- a/Form/FieldTypeHandler/Integer.php
+++ b/Form/FieldTypeHandler/Integer.php
@@ -60,7 +60,7 @@ class Integer extends FieldTypeHandler
      *
      * @return int
      */
-    public function convertFieldValueToForm( Value $value )
+    public function convertFieldValueToForm( Value $value, FieldDefinition $fieldDefinition )
     {
         return (int)$value->value;
     }

--- a/Form/FieldTypeHandler/Isbn.php
+++ b/Form/FieldTypeHandler/Isbn.php
@@ -22,7 +22,7 @@ class Isbn extends FieldTypeHandler
      *
      * @param IsbnValue $value
      */
-    public function convertFieldValueToForm( Value $value )
+    public function convertFieldValueToForm( Value $value, FieldDefinition $fieldDefinition )
     {
         return $value->isbn;
     }

--- a/Form/FieldTypeHandler/Isbn.php
+++ b/Form/FieldTypeHandler/Isbn.php
@@ -22,7 +22,7 @@ class Isbn extends FieldTypeHandler
      *
      * @param IsbnValue $value
      */
-    public function convertFieldValueToForm( Value $value, FieldDefinition $fieldDefinition )
+    public function convertFieldValueToForm( Value $value, FieldDefinition $fieldDefinition = null )
     {
         return $value->isbn;
     }

--- a/Form/FieldTypeHandler/Selection.php
+++ b/Form/FieldTypeHandler/Selection.php
@@ -50,7 +50,7 @@ class Selection extends FieldTypeHandler
      *
      * @return array
      */
-    public function convertFieldValueToForm( Value $value, FieldDefinition $fieldDefinition )
+    public function convertFieldValueToForm( Value $value, FieldDefinition $fieldDefinition = null )
     {
         return $value->selection;
     }

--- a/Form/FieldTypeHandler/Selection.php
+++ b/Form/FieldTypeHandler/Selection.php
@@ -50,7 +50,7 @@ class Selection extends FieldTypeHandler
      *
      * @return array
      */
-    public function convertFieldValueToForm( Value $value )
+    public function convertFieldValueToForm( Value $value, FieldDefinition $fieldDefinition )
     {
         return $value->selection;
     }

--- a/Form/FieldTypeHandler/TextBlock.php
+++ b/Form/FieldTypeHandler/TextBlock.php
@@ -18,10 +18,8 @@ class TextBlock extends FieldTypeHandler
 {
     /**
      * {@inheritdoc}
-     *
-     * @param \eZ\Publish\Core\FieldType\TextLine\Value $value
      */
-    public function convertFieldValueToForm( Value $value )
+    public function convertFieldValueToForm( Value $value, FieldDefinition $fieldDefinition )
     {
         return $value->text;
     }

--- a/Form/FieldTypeHandler/TextBlock.php
+++ b/Form/FieldTypeHandler/TextBlock.php
@@ -19,7 +19,7 @@ class TextBlock extends FieldTypeHandler
     /**
      * {@inheritdoc}
      */
-    public function convertFieldValueToForm( Value $value, FieldDefinition $fieldDefinition )
+    public function convertFieldValueToForm( Value $value, FieldDefinition $fieldDefinition = null )
     {
         return $value->text;
     }

--- a/Form/FieldTypeHandler/TextLine.php
+++ b/Form/FieldTypeHandler/TextLine.php
@@ -20,7 +20,7 @@ class TextLine extends FieldTypeHandler
     /**
      * {@inheritdoc}
      */
-    public function convertFieldValueToForm( Value $value, FieldDefinition $fieldDefinition )
+    public function convertFieldValueToForm( Value $value, FieldDefinition $fieldDefinition = null )
     {
         return $value->text;
     }

--- a/Form/FieldTypeHandler/TextLine.php
+++ b/Form/FieldTypeHandler/TextLine.php
@@ -19,10 +19,8 @@ class TextLine extends FieldTypeHandler
 {
     /**
      * {@inheritdoc}
-     *
-     * @param \eZ\Publish\Core\FieldType\TextLine\Value $value
      */
-    public function convertFieldValueToForm( Value $value )
+    public function convertFieldValueToForm( Value $value, FieldDefinition $fieldDefinition )
     {
         return $value->text;
     }

--- a/Form/FieldTypeHandler/Time.php
+++ b/Form/FieldTypeHandler/Time.php
@@ -39,7 +39,7 @@ class Time extends FieldTypeHandler
      *
      * @return int|null
      */
-    public function convertFieldValueToForm( Value $value )
+    public function convertFieldValueToForm( Value $value, FieldDefinition $fieldDefinition )
     {
         $time = $value->time;
         if ( is_int( $time ) )

--- a/Form/FieldTypeHandler/Time.php
+++ b/Form/FieldTypeHandler/Time.php
@@ -39,7 +39,7 @@ class Time extends FieldTypeHandler
      *
      * @return int|null
      */
-    public function convertFieldValueToForm( Value $value, FieldDefinition $fieldDefinition )
+    public function convertFieldValueToForm( Value $value, FieldDefinition $fieldDefinition = null )
     {
         $time = $value->time;
         if ( is_int( $time ) )

--- a/Form/FieldTypeHandler/Url.php
+++ b/Form/FieldTypeHandler/Url.php
@@ -32,7 +32,7 @@ class Url extends FieldTypeHandler
      *
      * @return array
      */
-    public function convertFieldValueToForm( Value $value, FieldDefinition $fieldDefinition )
+    public function convertFieldValueToForm( Value $value, FieldDefinition $fieldDefinition = null )
     {
         return array( 'url' => $value->link, 'text' => $value->text );
     }

--- a/Form/FieldTypeHandler/Url.php
+++ b/Form/FieldTypeHandler/Url.php
@@ -32,7 +32,7 @@ class Url extends FieldTypeHandler
      *
      * @return array
      */
-    public function convertFieldValueToForm( Value $value )
+    public function convertFieldValueToForm( Value $value, FieldDefinition $fieldDefinition )
     {
         return array( 'url' => $value->link, 'text' => $value->text );
     }

--- a/Form/FieldTypeHandler/User.php
+++ b/Form/FieldTypeHandler/User.php
@@ -17,10 +17,8 @@ class User extends FieldTypeHandler
 {
     /**
      * {@inheritdoc}
-     *
-     * @param \eZ\Publish\Core\FieldType\TextLine\Value $value
      */
-    public function convertFieldValueToForm( Value $value )
+    public function convertFieldValueToForm( Value $value, FieldDefinition $fieldDefinition )
     {
         // Returning null here because user data is mapped in mapper as an exceptional case
         return null;

--- a/Form/FieldTypeHandler/User.php
+++ b/Form/FieldTypeHandler/User.php
@@ -18,7 +18,7 @@ class User extends FieldTypeHandler
     /**
      * {@inheritdoc}
      */
-    public function convertFieldValueToForm( Value $value, FieldDefinition $fieldDefinition )
+    public function convertFieldValueToForm( Value $value, FieldDefinition $fieldDefinition = null )
     {
         // Returning null here because user data is mapped in mapper as an exceptional case
         return null;

--- a/Form/FieldTypeHandlerInterface.php
+++ b/Form/FieldTypeHandlerInterface.php
@@ -21,11 +21,11 @@ interface FieldTypeHandlerInterface
      * @see buildFieldUpdateForm
      *
      * @param \eZ\Publish\SPI\FieldType\Value $value
-     * @param \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition $fieldDefinition
+     * @param \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition|null $fieldDefinition
      *
      * @return mixed
      */
-    public function convertFieldValueToForm( Value $value, FieldDefinition $fieldDefinition );
+    public function convertFieldValueToForm( Value $value, FieldDefinition $fieldDefinition = null );
 
     /**
      * Converts the form data to a format that can be accepted by eZ Publish FieldType.

--- a/Form/FieldTypeHandlerInterface.php
+++ b/Form/FieldTypeHandlerInterface.php
@@ -21,10 +21,11 @@ interface FieldTypeHandlerInterface
      * @see buildFieldUpdateForm
      *
      * @param \eZ\Publish\SPI\FieldType\Value $value
+     * @param \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition $fieldDefinition
      *
      * @return mixed
      */
-    public function convertFieldValueToForm( Value $value );
+    public function convertFieldValueToForm( Value $value, FieldDefinition $fieldDefinition );
 
     /**
      * Converts the form data to a format that can be accepted by eZ Publish FieldType.


### PR DESCRIPTION
Some fields need more information in order to be displayed with Symfony Forms. As example is EnhancedSelection, which needs info when field can display and store multiple values.
