### PR TITLE
Fix typo caused by #31

### DIFF
--- a/Resources/config/form_fieldtype_handlers.yml
+++ b/Resources/config/form_fieldtype_handlers.yml
@@ -110,7 +110,7 @@ services:
             - {name: netgen.ezforms.form.fieldtype_handler, alias: ezgmaplocation}
 
     netgen.ezforms.form.fieldtype_handler.ezobjectrelation:
-        class: "%netgen.ezforms.form.fieldtype_handler.ezobjectrelation.class"
+        class: "%netgen.ezforms.form.fieldtype_handler.ezobjectrelation.class%"
         arguments:
           - "@ezpublish.api.repository"
           - "@ezpublish.translation_helper"


### PR DESCRIPTION
I missed a `%` at the end of the parameter.