### PR TITLE
Use early returns

### DIFF
--- a/Form/DataMapper.php
+++ b/Form/DataMapper.php
@@ -86,39 +86,43 @@ abstract class DataMapper implements DataMapperInterface
             // Write-back is disabled if the form is not synchronized (transformation failed),
             // if the form was not submitted and if the form is disabled (modification not allowed)
             if (
-                null !== $propertyPath &&
-                $config->getMapped() &&
-                $form->isSubmitted() &&
-                $form->isSynchronized() &&
-                !$form->isDisabled()
+                null === $propertyPath ||
+                !$config->getMapped() ||
+                !$form->isSubmitted() ||
+                !$form->isSynchronized() ||
+                $form->isDisabled()
             ) {
-                // If $data is out ContentCreateStruct, we need to map it to the corresponding field
-                // in the struct
-                if ($data instanceof DataWrapper) {
-                    /** @var $data \Netgen\Bundle\EzFormsBundle\Form\DataWrapper */
-                    $this->mapFromForm($form, $data, $propertyPath);
-                }
-                // If the data is identical to the value in $data, we are
-                // dealing with a reference
-                else {
-                    // If the field is of type DateTime and the data is the same skip the update to
-                    // keep the original object hash
-                    if (
-                        $form->getData() instanceof \DateTime &&
-                        $form->getData() == $this->propertyAccessor->getValue($data, $propertyPath)
-                    ) {
-                        continue;
-                    }
-
-                    if (
-                        !is_object($data) ||
-                        !$config->getByReference() ||
-                        $form->getData() !== $this->propertyAccessor->getValue($data, $propertyPath)
-                    ) {
-                        $this->propertyAccessor->setValue($data, $propertyPath, $form->getData());
-                    }
-                }
+                continue;
             }
+
+            // If $data is out ContentCreateStruct, we need to map it to the corresponding field
+            // in the struct
+            if ($data instanceof DataWrapper) {
+                /** @var $data \Netgen\Bundle\EzFormsBundle\Form\DataWrapper */
+                $this->mapFromForm($form, $data, $propertyPath);
+                continue;
+            }
+
+            // If the field is of type DateTime and the data is the same skip the update to
+            // keep the original object hash
+            if (
+                $form->getData() instanceof \DateTime &&
+                $form->getData() == $this->propertyAccessor->getValue($data, $propertyPath)
+            ) {
+                continue;
+            }
+
+            // If the data is identical to the value in $data, we are
+            // dealing with a reference
+            if (
+                is_object($data) &&
+                $config->getByReference() &&
+                $form->getData() === $this->propertyAccessor->getValue($data, $propertyPath)
+            ) {
+                continue;
+            }
+
+            $this->propertyAccessor->setValue($data, $propertyPath, $form->getData());
         }
     }
 


### PR DESCRIPTION
This PR updates the DataMapper class to use early returns to make the code more comprehensible.