### PR TITLE
Object Relation BugFix in Update Mode

### DIFF
--- a/bundle/Form/FieldTypeHandler/Relation.php
+++ b/bundle/Form/FieldTypeHandler/Relation.php
@@ -71,6 +71,6 @@ class Relation extends FieldTypeHandler
             return null;
         }
 
-        return $this->repository->getContentService()->loadContent($value->destinationContentId);
+        return $value->destinationContentId;
     }
 }

--- a/tests/Form/FieldTypeHandler/RelationTest.php
+++ b/tests/Form/FieldTypeHandler/RelationTest.php
@@ -97,14 +97,14 @@ class RelationTest extends TestCase
         $this->contentService->expects($this->once())
             ->method('loadContent')
             ->with($destinationContentId)
-            ->willReturn('foo');
+            ->willReturn($destinationContentId);
 
         $relation = new Relation($this->repository, $this->translationHelper);
         $relationValue = new RelationValue(2);
 
         $returnedValue = $relation->convertFieldValueToForm($relationValue);
 
-        $this->assertEquals('foo', $returnedValue);
+        $this->assertEquals($destinationContentId, $returnedValue);
     }
 
     public function testConvertFieldValueToFormNullDestinationContentId()

--- a/tests/Form/FieldTypeHandler/RelationTest.php
+++ b/tests/Form/FieldTypeHandler/RelationTest.php
@@ -93,18 +93,12 @@ class RelationTest extends TestCase
 
     public function testConvertFieldValueToForm()
     {
-        $destinationContentId = 2;
-        $this->contentService->expects($this->once())
-            ->method('loadContent')
-            ->with($destinationContentId)
-            ->willReturn($destinationContentId);
-
         $relation = new Relation($this->repository, $this->translationHelper);
         $relationValue = new RelationValue(2);
 
         $returnedValue = $relation->convertFieldValueToForm($relationValue);
 
-        $this->assertEquals($destinationContentId, $returnedValue);
+        $this->assertEquals(2, $returnedValue);
     }
 
     public function testConvertFieldValueToFormNullDestinationContentId()


### PR DESCRIPTION
in the "Content Update" Mode when having an Object Relation and a location is already selected for that objectRelation field, we get currently an error saying:
" Catchable Fatal Error: Object of class eZ\Publish\Core\Repository\Values\Content\Content could not be converted to string "

and it is because the "eZ\Publish\Core\Repository\Values\Content\Content" Class does not have a __toString() method.

This workaround solved the problem for me. you can merge it if you feel this can be a general solution for all or just decline it if you don't feel so :)