### PR TITLE
Fix error for integer field type

### DIFF
--- a/bundle/Form/FieldTypeHandler/IntegerHandler.php
+++ b/bundle/Form/FieldTypeHandler/IntegerHandler.php
@@ -52,11 +52,11 @@ class IntegerHandler extends FieldTypeHandler
             $min = $fieldDefinition->getValidatorConfiguration()['IntegerValueValidator']['minIntegerValue'];
             $max = $fieldDefinition->getValidatorConfiguration()['IntegerValueValidator']['maxIntegerValue'];
 
-            if ($min !== false) {
+            if ($min !== null) {
                 $rangeConstraints['min'] = $min;
             }
 
-            if ($max !== false) {
+            if ($max !== null) {
                 $rangeConstraints['max'] = $max;
             }
 


### PR DESCRIPTION
integer field type returns 'null' for not specified min or max values rather than 'false'. 

See
https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/Core/FieldType/Integer/Type.php#L29 
and 
https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/Core/FieldType/Integer/Type.php#L33