### PR TITLE
Add a RelationList form field type handler

### DIFF
--- a/bundle/Form/FieldTypeHandler/RelationList.php
+++ b/bundle/Form/FieldTypeHandler/RelationList.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Netgen\Bundle\EzFormsBundle\Form\FieldTypeHandler;
+
+use eZ\Publish\API\Repository\Repository;
+use eZ\Publish\API\Repository\Values\Content\Content;
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
+use eZ\Publish\SPI\FieldType\Value;
+use Netgen\Bundle\EzFormsBundle\Form\FieldTypeHandler;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class RelationList extends FieldTypeHandler
+{
+    const BROWSE = 0;
+    const DROPDOWN = 1;
+    const LIST_RADIO = 2;
+    const LIST_CHECK = 3;
+    const MULTIPLE_SELECTION = 4;
+    const TPLBASED_MULTI = 5;
+    const TPLBASED_SINGLE = 6;
+
+    /**
+     * @var Repository
+     */
+    private $repository;
+
+    public function __construct(
+        Repository $repository
+    )
+    {
+        $this->repository = $repository;
+    }
+
+    protected function buildFieldForm(
+        FormBuilderInterface $formBuilder,
+        FieldDefinition $fieldDefinition,
+        $languageCode,
+        Content $content = null
+    )
+    {
+        $options = $this->getDefaultFieldOptions($fieldDefinition, $languageCode, $content);
+
+        $fieldSettings = $fieldDefinition->getFieldSettings();
+
+        $selectionMethod = $fieldSettings['selectionMethod'];
+
+        $defaultLocation = $fieldSettings['selectionDefaultLocation'];
+        $contentTypes = $fieldSettings['selectionContentTypes'];
+        
+        /* TODO: implement different selection methods */
+        switch ($fieldSettings['selectionMethod']) {
+            default:
+                $locationService = $this->repository->getLocationService();
+                $location = $locationService->loadLocation($defaultLocation ? $defaultLocation : 2);
+                $locationList = $locationService->loadLocationChildren($location);
+
+                $choices = [];
+                foreach ($locationList->locations as $child) {
+                    /** @var Location $child */
+                    $choices[$this->translationHelper->getTranslatedContentNameByContentInfo($child->contentInfo)] = $child->contentInfo->id;
+                }
+
+                $formBuilder->add($fieldDefinition->identifier, ChoiceType::class, [
+                    'choices' => $choices,
+                    'expanded' => false,
+                    'multiple' => false,
+                    'choices_as_values' => true,
+                ], $options);
+                break;
+        }
+    }
+
+    public function convertFieldValueToForm(Value $value, FieldDefinition $fieldDefinition = null)
+    {
+        if (empty($value->destinationContentIds)) {
+            return null;
+        }
+
+        return $value->destinationContentIds;
+    }
+
+    public function convertFieldValueFromForm($data)
+    {
+        return new RelationListValue($data);
+    }
+}

--- a/bundle/Resources/config/form_fieldtype_handlers.yml
+++ b/bundle/Resources/config/form_fieldtype_handlers.yml
@@ -122,5 +122,6 @@ services:
         class: "%netgen.ezforms.form.fieldtype_handler.ezobjectrelationlist.class%"
         arguments:
           - "@ezpublish.api.repository"
+          - "@ezpublish.translation_helper"
         tags:
             - {name: netgen.ezforms.form.fieldtype_handler, alias: ezobjectrelationlist}            

--- a/bundle/Resources/config/form_fieldtype_handlers.yml
+++ b/bundle/Resources/config/form_fieldtype_handlers.yml
@@ -17,6 +17,7 @@ parameters:
     netgen.ezforms.form.fieldtype_handler.ezbinaryfile.class: Netgen\Bundle\EzFormsBundle\Form\FieldTypeHandler\BinaryFile
     netgen.ezforms.form.fieldtype_handler.ezgmaplocation.class: Netgen\Bundle\EzFormsBundle\Form\FieldTypeHandler\MapLocation
     netgen.ezforms.form.fieldtype_handler.ezobjectrelation.class: Netgen\Bundle\EzFormsBundle\Form\FieldTypeHandler\Relation
+    netgen.ezforms.form.fieldtype_handler.ezobjectrelationlist.class: Netgen\Bundle\EzFormsBundle\Form\FieldTypeHandler\RelationList
 
 services:
     netgen.ezforms.form.fieldtype_handler.ezimage:
@@ -116,3 +117,10 @@ services:
           - "@ezpublish.translation_helper"
         tags:
             - {name: netgen.ezforms.form.fieldtype_handler, alias: ezobjectrelation}
+            
+    netgen.ezforms.form.fieldtype_handler.ezobjectrelationlist:
+        class: "%netgen.ezforms.form.fieldtype_handler.ezobjectrelationlist.class%"
+        arguments:
+          - "@ezpublish.api.repository"
+        tags:
+            - {name: netgen.ezforms.form.fieldtype_handler, alias: ezobjectrelationlist}            


### PR DESCRIPTION
This is a very shallow implementation of the ezobjectrelationlist form field type handler which only shows a dropdown. It is prepped to be expanded with other selection types, though, and a switch statement controls the possible implementations of the other selection types in question.