### PR TITLE
Fix ezcountry mapping to form

### DIFF
--- a/bundle/Form/FieldTypeHandler/Country.php
+++ b/bundle/Form/FieldTypeHandler/Country.php
@@ -61,12 +61,10 @@ class Country extends FieldTypeHandler
 
             $keys = array_keys($value->countries);
 
-            return array(
-                $keys[0] => $value->countries[$keys[0]],
-            );
+            return reset($keys);
         }
 
-        return $value->countries;
+        return array_keys($value->countries);
     }
 
     /**

--- a/tests/Form/FieldTypeHandler/CountryTest.php
+++ b/tests/Form/FieldTypeHandler/CountryTest.php
@@ -39,7 +39,7 @@ class CountryTest extends TestCase
 
         $returnedValue = $country->convertFieldValueToForm($countryValue);
 
-        $this->assertEquals($countries, $returnedValue);
+        $this->assertEquals(['HR'], $returnedValue);
     }
 
     public function testConvertFieldValueToFormMultipleValues()
@@ -88,7 +88,7 @@ class CountryTest extends TestCase
 
         $returnedValue = $country->convertFieldValueToForm($countryValue, $fieldDefinition);
 
-        $this->assertEquals($selectedCountries, $returnedValue);
+        $this->assertEquals(['HR', 'BB'], $returnedValue);
     }
 
     public function testConvertFieldValueToFormSingleValue()
@@ -132,7 +132,7 @@ class CountryTest extends TestCase
 
         $returnedValue = $country->convertFieldValueToForm($countryValue, $fieldDefinition);
 
-        $this->assertEquals($selectedCountries, $returnedValue);
+        $this->assertEquals('HR', $returnedValue);
     }
 
     public function testConvertFieldValueToFormWithNoneSelected()


### PR DESCRIPTION
This seems to be a bug and has been observed when trying to map a field of type 'ezcountry' on a InformationCollector to a symfony form.

When creating the symfony form, the form is expecting the list of values as strings, for example ['FR', 'HR'] but the mapping is retrieving the list of countries : 
[ 'HR' => [ 'Name' => 'Croatia', 'Code' => 'HR', 'Language' => 'cro-HR', ],
 'FR' => [ 'Name' => 'France', 'Code' => 'FR', 'Language' => 'fre-FR', ],]